### PR TITLE
Add ability to use other API instances

### DIFF
--- a/pyosmapi/osm_api.py
+++ b/pyosmapi/osm_api.py
@@ -21,7 +21,7 @@ class OsmApi:
         """
         :returns: supported API versions
         """
-        data = requests.get('https://api.openstreetmap.org/api' + '/versions')
+        data = requests.get(self.base_url + '/versions')
         if data.ok:
             return ElemTree.fromstring(data.text).find('api/version').text
         self.__more_error(data)

--- a/pyosmapi/osm_api.py
+++ b/pyosmapi/osm_api.py
@@ -9,11 +9,13 @@ logger = logging.getLogger(__name__)
 
 
 class OsmApi:
-    base_url = 'https://master.apis.dev.openstreetmap.org/api/0.6'
-
-    def __init__(self, live: bool = False):
-        if live:
-            self.base_url = 'https://api.openstreetmap.org/api/0.6'
+    def __init__(self, instance: str = "dev"):
+        if instance == "main":
+            self.base_url = DEFAULT_OSM_URL
+        elif instance == "dev":
+            self.base_url = DEFAULT_OSM_DEV_URL
+        else:
+            self.base_url = instance
 
     def get_api_versions(self):
         """

--- a/pyosmapi/osm_api.py
+++ b/pyosmapi/osm_api.py
@@ -9,6 +9,13 @@ logger = logging.getLogger(__name__)
 
 
 class OsmApi:
+    """
+    Connects to the OSM API to get or change data.
+
+    for param instance use either
+    `dev <https://master.apis.dev.openstreetmap.org>`_ or `main <https://api.openstreetmap.org>`_  API
+
+    """
     def __init__(self, instance: str = "dev"):
         self.url_extension = '/api/0.6'
         if instance.lower() == "main":
@@ -127,7 +134,8 @@ class OsmApi:
         self.__kv_serial(changeset.tags, cs)
         xml = ElemTree.tostring(root)
 
-        data = requests.put(self.base_url + self.url_extension + '/changeset/{}'.format(changeset.id), data=xml, auth=auth)
+        data = requests.put(self.base_url + self.url_extension + '/changeset/{}'.format(changeset.id),
+                            data=xml, auth=auth)
         if data.ok:
             return None
         elif data.status_code == HTTPStatus.CONFLICT:
@@ -233,7 +241,8 @@ class OsmApi:
         :param auth: either OAuth1 object or tuple (username, password)
         :returns: list with dict {type, old_id, new_id, new_version}
         """
-        data = requests.post(self.base_url + self.url_extension + '/changeset/{}/upload'.format(cid), data=xml, auth=auth)
+        data = requests.post(self.base_url + self.url_extension + '/changeset/{}/upload'.format(cid),
+                             data=xml, auth=auth)
         if data.ok:
             changes = []
             tree = ElemTree.fromstring(data.text)
@@ -558,7 +567,8 @@ class OsmApi:
         :raises NoneFoundError: requested object never existed
         :raises MethodError: you might never try ro request more than ~700 elements at once
         """
-        data = requests.get(self.base_url + self.url_extension + '/{}s?{}s={}'.format(e_type, e_type, ','.join(map(str, lst_eid))))
+        data = requests.get(self.base_url + self.url_extension + '/{}s?{}s={}'.format(e_type, e_type,
+                                                                                      ','.join(map(str, lst_eid))))
         if data.ok:
             tree = ElemTree.fromstring(data.text)
             logger.debug(data.text)
@@ -665,7 +675,8 @@ class OsmApi:
         :param page: 5000 trackpoints are returned each page
         :returns: format GPX Version 1.0 string
         """
-        data = requests.get(self.base_url + self.url_extension + '/trackpoints', params={'bbox': ','.join(map(str, bbox)), 'page': page})
+        data = requests.get(self.base_url + self.url_extension + '/trackpoints',
+                            params={'bbox': ','.join(map(str, bbox)), 'page': page})
         if data.ok:
             return data.text
         self.__more_error(data)
@@ -687,7 +698,8 @@ class OsmApi:
         """
         content = {'description': description, 'tags': ','.join(tags), 'visibility': visibility}
         req_file = {'file': (name, trace)}
-        data = requests.post(self.base_url + self.url_extension + '/gpx/create', auth=auth, files=req_file, data=content)
+        data = requests.post(self.base_url + self.url_extension + '/gpx/create',
+                             auth=auth, files=req_file, data=content)
         if data.ok:
             return int(data.text)
         self.__more_error(data)
@@ -709,7 +721,8 @@ class OsmApi:
         """
         content = {'description': description, 'tags': ','.join(tags), 'public': public, 'visibility': visibility}
         req_file = {'file': ('test-trace.gpx', trace)}
-        data = requests.put(self.base_url + self.url_extension + '/gpx/' + str(tid), auth=auth, files=req_file, data=content)
+        data = requests.put(self.base_url + self.url_extension + '/gpx/' + str(tid),
+                            auth=auth, files=req_file, data=content)
         if data.ok:
             logger.debug('updated')
         else:
@@ -904,7 +917,8 @@ class OsmApi:
         :param value: new value
         :param auth: either OAuth1 object or tuple (username, password)
         """
-        data = requests.put(self.base_url + self.url_extension + '/user/preferences/{}'.format(key), data=value, auth=auth)
+        data = requests.put(self.base_url + self.url_extension + '/user/preferences/{}'.format(key),
+                            data=value, auth=auth)
         if data.ok:
             return None
         self.__more_error(data)
@@ -959,8 +973,8 @@ class OsmApi:
         :returns: list of Notes
         :raises ValueError: When any of the limits are crossed
         """
-        data = requests.get(self.base_url + self.url_extension + '/notes', params={'bbox': ','.join(map(str, bbox)),
-                                                              'limit': limit, 'closed': closed})
+        data = requests.get(self.base_url + self.url_extension + '/notes',
+                            params={'bbox': ','.join(map(str, bbox)), 'limit': limit, 'closed': closed})
         logger.debug(data.text)
         if data.ok:
             tree = ElemTree.fromstring(data.text)
@@ -998,7 +1012,8 @@ class OsmApi:
         :returns: note ID
         :raises ValueError: No text field
         """
-        data = requests.post(self.base_url + self.url_extension + '/notes', params={'lat': lat, 'lon': lon, 'text': text}, auth=auth)
+        data = requests.post(self.base_url + self.url_extension + '/notes',
+                             params={'lat': lat, 'lon': lon, 'text': text}, auth=auth)
         logger.debug(data.text)
         if data.ok:
             tree = ElemTree.fromstring(data.text)

--- a/pyosmapi/osm_api.py
+++ b/pyosmapi/osm_api.py
@@ -10,9 +10,9 @@ logger = logging.getLogger(__name__)
 
 class OsmApi:
     def __init__(self, instance: str = "dev"):
-        if instance == "main":
+        if instance.lower() == "main":
             self.base_url = DEFAULT_OSM_URL
-        elif instance == "dev":
+        elif instance.lower() == "dev":
             self.base_url = DEFAULT_OSM_DEV_URL
         else:
             self.base_url = instance

--- a/pyosmapi/osm_util.py
+++ b/pyosmapi/osm_util.py
@@ -2,7 +2,9 @@ import json
 import math
 from datetime import datetime
 
-OSM_URL = 'https://master.apis.dev.openstreetmap.org'
+
+DEFAULT_OSM_DEV_URL = 'https://master.apis.dev.openstreetmap.org'
+DEFAULT_OSM_URL = 'https://api.openstreetmap.org'
 
 
 class Element:


### PR DESCRIPTION
This adds the ability to use other API instances by removing the `live: bool = False` parameter from the OsmApi class and instead replacing it with `instance: str = "dev"`.
The two values `"dev"` and `"main"` point to <https://master.apis.dev.openstreetmap.org> and <https://api.openstreetmap.org> respectively, and any other value will be used as the URL.

I have not added any tests or documentation on this (I'm unsure on how you're doing the docstrings)