### PR TITLE
Revert "Add ability to use other API instances"

### DIFF
--- a/pyosmapi/osm_api.py
+++ b/pyosmapi/osm_api.py
@@ -12,12 +12,12 @@ class OsmApi:
     """
     Connects to the OSM API to get or change data.
 
-    for param instance use either
-    `dev <https://master.apis.dev.openstreetmap.org>`_ or `main <https://api.openstreetmap.org>`_  API
-
+    :param instance: keywords dev and main are mapped to the official osm.org  or set a custom url
+    :param url_extension: path to the api defaults to '/api/6.0'
     """
-    def __init__(self, instance: str = "dev"):
-        self.url_extension = '/api/0.6'
+
+    def __init__(self, instance: str = "dev", url_extension: str = "/api/0.6"):
+        self.url_extension = url_extension
         if instance.lower() == "main":
             self.base_url = DEFAULT_OSM_URL
             logger.info('Using osm main api')
@@ -25,8 +25,8 @@ class OsmApi:
             self.base_url = DEFAULT_OSM_DEV_URL
             logger.info('Using osm dev api')
         else:
-            logger.warning('Key not found, using osm dev api..')
-            self.base_url = DEFAULT_OSM_DEV_URL
+            self.base_url = instance
+            logger. info(f'Using custom instance: {instance}{url_extension}')
 
     def get_api_versions(self):
         """

--- a/pyosmapi/osm_util.py
+++ b/pyosmapi/osm_util.py
@@ -2,8 +2,8 @@ import json
 import math
 from datetime import datetime
 
-OSM_URL = 'https://master.apis.dev.openstreetmap.org'
-
+DEFAULT_OSM_DEV_URL = 'https://master.apis.dev.openstreetmap.org'
+DEFAULT_OSM_URL = 'https://api.openstreetmap.org'
 
 class Element:
     def __init__(self, eid: int, version: int, changeset: int,
@@ -146,10 +146,6 @@ class Trace:
     @property
     def id(self):
         return self._id
-
-    @staticmethod
-    def url(osm_user, tid):
-        return OSM_URL + '/user/' + osm_user + '/traces/' + tid
 
 
 class ChangeSet:

--- a/test/test_osm_api.py
+++ b/test/test_osm_api.py
@@ -6,7 +6,7 @@ import pyosmapi.osm_util
 
 
 class MyTestCase(unittest.TestCase):
-    osmo = osmapi.OsmApi()
+    osmo = osmapi.OsmApi('dev')
 
     def auth(self):
         try:


### PR DESCRIPTION
Reverts jonycoo/py-osmapi#1
Ok, now I understand your intend, cool idea, I just didn't understand.

The Original pull request should have added the ability for developers to set a custom url as the instance.